### PR TITLE
Enable to apply `Result<T, E>` to any types

### DIFF
--- a/rest/pages.ts
+++ b/rest/pages.ts
@@ -49,8 +49,12 @@ export async function getPage(
   );
 
   if (!res.ok) {
-    const error = tryToErrorLike(await res.text());
-    if (!error) {
+    const value = tryToErrorLike(await res.text()) as
+      | false
+      | NotFoundError
+      | NotLoggedInError
+      | NotMemberError;
+    if (!value) {
       throw makeCustomError(
         "UnexpectedError",
         `Unexpected error has occuerd when fetching "${path}"`,
@@ -58,9 +62,9 @@ export async function getPage(
     }
     return {
       ok: false,
-      ...(error as (NotFoundError | NotLoggedInError | NotMemberError)),
+      value,
     };
   }
-  const result = (await res.json()) as Page;
-  return { ok: true, ...result };
+  const value = (await res.json()) as Page;
+  return { ok: true, value };
 }

--- a/rest/utils.ts
+++ b/rest/utils.ts
@@ -6,23 +6,23 @@ import type { ErrorLike } from "../deps/scrapbox.ts";
  */
 export const cookie = (sid: string) => `connect.sid=${sid}`;
 
-export type Result<T, E> = ({ ok: true } & T) | ({ ok: false } & E);
+export type Result<T, E> = { ok: true; value: T } | { ok: false; value: E };
 /** CSRF tokenを取得する
  *
  * @param sid - connect.sidに入っている文字列。不正な文字列を入れてもCSRF tokenを取得できるみたい
  */
 export async function getCSRFToken(
   sid: string,
-): Promise<Result<{ csrfToken: string }, ErrorLike>> {
+): Promise<Result<string, ErrorLike>> {
   const res = await fetch("https://scrapbox.io/api/users/me", {
     headers: { Cookie: cookie(sid) },
   });
   if (!res.ok) {
-    const error = (await res.json()) as ErrorLike;
-    return { ok: false, ...error };
+    const value = (await res.json()) as ErrorLike;
+    return { ok: false, value };
   }
   const { csrfToken } = (await res.json()) as { csrfToken: string };
-  return { ok: true, csrfToken };
+  return { ok: true, value: csrfToken };
 }
 
 // cf. https://blog.uhy.ooo/entry/2021-04-09/typescript-is-any-as/#%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E5%AE%9A%E7%BE%A9%E5%9E%8B%E3%82%AC%E3%83%BC%E3%83%89%E3%81%AE%E5%BC%95%E6%95%B0%E3%81%AE%E5%9E%8B%E3%82%92%E3%81%A9%E3%81%86%E3%81%99%E3%82%8B%E3%81%8B


### PR DESCRIPTION
see [⬜scrapbox-userscript-stdのError Objectを変える](https://scrapbox.io/takker/⬜scrapbox-userscript-stdのError_Objectを変える)