### PR TITLE
:sparkles: Enable to create readable titles for URL

### DIFF
--- a/title.test.ts
+++ b/title.test.ts
@@ -1,4 +1,9 @@
-import { encodeTitleURI, revertTitleLc, toTitleLc } from "./title.ts";
+import {
+  encodeTitleURI,
+  revertTitleLc,
+  toReadableTitleURI,
+  toTitleLc,
+} from "./title.ts";
 import { assertStrictEquals } from "./deps/testing.ts";
 
 Deno.test("toTitleLc()", async (t) => {
@@ -35,5 +40,39 @@ Deno.test("revertTitleLc()", () => {
 Deno.test("encodeTitleURI()", async (t) => {
   await t.step("tail symbol", () => {
     assertStrictEquals<string>(encodeTitleURI(":title:"), ":title%3A");
+  });
+});
+
+Deno.test("toReadableTitleURI()", async (t) => {
+  await t.step("only \\w", () => {
+    assertStrictEquals<string>(
+      toReadableTitleURI("Normal_TitleAAA"),
+      "Normal_TitleAAA",
+    );
+  });
+
+  await t.step("with sparce", () => {
+    assertStrictEquals<string>(
+      toReadableTitleURI("Title with Spaces"),
+      "Title_with_Spaces",
+    );
+  });
+
+  await t.step("with multibyte characters", () => {
+    assertStrictEquals<string>(
+      toReadableTitleURI("日本語_(絵文字✨つき)　タイトル"),
+      "日本語_(絵文字✨つき)　タイトル",
+    );
+  });
+
+  await t.step("encoding //", () => {
+    assertStrictEquals<string>(
+      toReadableTitleURI("スラッシュ/は/percent encoding対象の/文字です"),
+      "スラッシュ%2Fは%2Fpercent_encoding対象の%2F文字です",
+    );
+    assertStrictEquals<string>(
+      toReadableTitleURI("%2Fなども/と同様percent encodingされる"),
+      "%252Fなども%2Fと同様percent_encodingされる",
+    );
   });
 });

--- a/title.ts
+++ b/title.ts
@@ -40,3 +40,13 @@ export const encodeTitleURI = (title: string): string => {
 
 const noEncodeChars = '@$&+=:;",';
 const noTailChars = ':;",';
+
+/** titleをできるだけpercent encodingせずにURIで使える形式にする
+ *
+ * @param title 変換するtitle
+ * @return 変換後の文字列
+ */
+export const toReadableTitleURI = (title: string): string => {
+  return title.replaceAll(" ", "_")
+    .replace(/[/?#\{}^|<>]/g, (char) => encodeURIComponent(char));
+};

--- a/title.ts
+++ b/title.ts
@@ -48,5 +48,5 @@ const noTailChars = ':;",';
  */
 export const toReadableTitleURI = (title: string): string => {
   return title.replaceAll(" ", "_")
-    .replace(/[/?#\{}^|<>]/g, (char) => encodeURIComponent(char));
+    .replace(/[/?#\{}^|<>%]/g, (char) => encodeURIComponent(char));
 };


### PR DESCRIPTION
close [⬜なるべくpercent encodingしないタイトルを作](https://scrapbox.io/takker/⬜なるべくpercent_encodingしないタイトルを作)