### PR TITLE
✨ Implement the wrapper for /api/projects

### DIFF
--- a/deps/scrapbox-rest.ts
+++ b/deps/scrapbox-rest.ts
@@ -16,9 +16,11 @@ export type {
   NotPrivilegeError,
   Page,
   PageList,
+  ProjectId,
+  ProjectResponse,
   ProjectSearchResult,
   SearchedTitle,
   SearchResult,
   SessionError,
   TweetInfo,
-} from "https://raw.githubusercontent.com/scrapbox-jp/types/0.3.3/rest.ts";
+} from "https://raw.githubusercontent.com/scrapbox-jp/types/0.3.4/rest.ts";

--- a/deps/scrapbox.ts
+++ b/deps/scrapbox.ts
@@ -1,8 +1,8 @@
 export type {
   Line,
   Scrapbox,
-} from "https://raw.githubusercontent.com/scrapbox-jp/types/0.3.3/userscript.ts";
+} from "https://raw.githubusercontent.com/scrapbox-jp/types/0.3.4/userscript.ts";
 export type {
   BaseStore,
-} from "https://raw.githubusercontent.com/scrapbox-jp/types/0.3.3/baseStore.ts";
+} from "https://raw.githubusercontent.com/scrapbox-jp/types/0.3.4/baseStore.ts";
 export * from "https://esm.sh/@progfay/scrapbox-parser@7.2.0";

--- a/deps/testing.ts
+++ b/deps/testing.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.136.0/testing/asserts.ts";
+export * from "https://deno.land/std@0.137.0/testing/asserts.ts";

--- a/rest/project.ts
+++ b/rest/project.ts
@@ -4,6 +4,8 @@ import type {
   NotLoggedInError,
   NotMemberError,
   NotMemberProject,
+  ProjectId,
+  ProjectResponse,
 } from "../deps/scrapbox-rest.ts";
 import { cookie } from "./auth.ts";
 import { UnexpectedResponseError } from "./error.ts";
@@ -48,5 +50,45 @@ export const getProject = async (
   }
 
   const value = (await res.json()) as MemberProject | NotMemberProject;
+  return { ok: true, value };
+};
+
+/** list the projects' information
+ *
+ * @param projectIds project ids. This must have more than 1 id
+ * @param init connect.sid etc.
+ */
+export const listProjects = async (
+  projectIds: ProjectId[],
+  init?: BaseOptions,
+): Promise<Result<ProjectResponse, NotLoggedInError>> => {
+  const { sid, hostName, fetch } = setDefaults(init ?? {});
+  const param = new URLSearchParams();
+  for (const id of projectIds) {
+    param.append("ids", id);
+  }
+  const path = `https://${hostName}/api/projects?${param.toString()}`;
+  const res = await fetch(
+    path,
+    sid ? { headers: { Cookie: cookie(sid) } } : undefined,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    const value = tryToErrorLike(text);
+    if (!value) {
+      throw new UnexpectedResponseError({
+        path: new URL(path),
+        ...res,
+        body: text,
+      });
+    }
+    return {
+      ok: false,
+      value: value as NotLoggedInError,
+    };
+  }
+
+  const value = (await res.json()) as ProjectResponse;
   return { ok: true, value };
 };


### PR DESCRIPTION
see [📝Scrapbox REST APIのwrapperを実装する](https://scrapbox.io/takker/📝Scrapbox_REST_APIのwrapperを実装する)