### PR TITLE
:bug: Faild to proceed when code blocks are not found

### DIFF
--- a/rest/getCodeBlock.ts
+++ b/rest/getCodeBlock.ts
@@ -27,7 +27,13 @@ const getCodeBlock_toRequest: GetCodeBlock["toRequest"] = (
 
 const getCodeBlock_fromResponse: GetCodeBlock["fromResponse"] = async (res) => {
   if (!res.ok) {
-    return makeError<NotFoundError | NotLoggedInError | NotMemberError>(res);
+    return res.status === 404 &&
+        res.headers.get("Content-Type")?.includes?.("text/plain")
+      ? {
+        ok: false,
+        value: { name: "NotFoundError", message: "Code block is not found" },
+      }
+      : makeError<NotFoundError | NotLoggedInError | NotMemberError>(res);
   }
   return { ok: true, value: await res.text() };
 };


### PR DESCRIPTION
close [⬜api/code/:projectname/:pagetitle/:filenameが404 not foundを返すときに対応できていない](https://scrapbox.io/takker/⬜api%2Fcode%2F:projectname%2F:pagetitle%2F:filenameが404_not_foundを返すときに対応できていない)