### PR TITLE
:bug: Faild to update pages which include `[/:project]` or `[/:project/]`

### DIFF
--- a/browser/websocket/makeChanges.ts
+++ b/browser/websocket/makeChanges.ts
@@ -107,6 +107,8 @@ const findLinksAndImage = (
           }
           case "root": {
             const link = cutId(node.href);
+            // ignore `/project` or `/project/`
+            if (/^\/[\w\d-]+\/?$/.test(link)) return;
             if (projectLinksLc.has(toTitleLc(link))) return;
             projectLinksLc.add(toTitleLc(link));
             projectLinks.push(link);


### PR DESCRIPTION
see [✅scrapbox-userscript-stdでExternal Linksを更新できるようにする](https://scrapbox.io/takker/✅scrapbox-userscript-stdでExternal_Linksを更新できるようにする#64f5350f1280f00000d98a94)