### PR TITLE
feat(websocket): Prevent named links of youtube from being selected as the thumbnail

### DIFF
--- a/browser/websocket/findMetadata.ts
+++ b/browser/websocket/findMetadata.ts
@@ -78,6 +78,7 @@ export const findMetadata = (
             return;
           }
           case "absolute": {
+            if (node.content) return;
             const props = parseYoutube(node.href);
             if (props && props.pathType !== "list") {
               image ??= `https://i.ytimg.com/vi/${props.videoId}/mqdefault.jpg`;


### PR DESCRIPTION
close [⬜️タイトル付きyoutubeリンクはサムネイルにしない (scrapbox-userscript-std)](https://scrapbox.io/takker/⬜️タイトル付きyoutubeリンクはサムネイルにしない_(scrapbox-userscript-std))