### PR TITLE
refactor: Use pre- defined `BaseLine`  type

### DIFF
--- a/browser/websocket/applyCommit.ts
+++ b/browser/websocket/applyCommit.ts
@@ -1,7 +1,6 @@
 import type { CommitNotification } from "./websocket-types.ts";
-import type { Page } from "@cosense/types/rest";
+import type { BaseLine } from "@cosense/types/rest";
 import { getUnixTimeFromId } from "./id.ts";
-type Line = Page["lines"][number];
 
 export interface ApplyCommitProp {
   /** changesの作成日時
@@ -19,10 +18,10 @@ export interface ApplyCommitProp {
  * @param changes 適用するcommits
  */
 export const applyCommit = (
-  lines: readonly Line[],
+  lines: readonly BaseLine[],
   changes: CommitNotification["changes"],
   { updated, userId }: ApplyCommitProp,
-): Line[] => {
+): BaseLine[] => {
   const newLines = [...lines];
   const getPos = (lineId: string) => {
     const position = newLines.findIndex(({ id }) => id === lineId);

--- a/browser/websocket/patch.ts
+++ b/browser/websocket/patch.ts
@@ -1,12 +1,11 @@
 import type { Change, DeletePageChange, PinChange } from "./wrap.ts";
 import { makeChanges } from "./makeChanges.ts";
-import type { Page } from "@cosense/types/rest";
+import type { BaseLine, Page } from "@cosense/types/rest";
 import { push, type PushError, type PushOptions } from "./push.ts";
 import { suggestUnDupTitle } from "./suggestUnDupTitle.ts";
 import type { Result } from "option-t/plain_result";
 
 export type PatchOptions = PushOptions;
-type Line = Page["lines"][number];
 
 export interface PatchMetadata extends Page {
   /** 書き換えを再試行した回数
@@ -29,7 +28,7 @@ export const patch = (
   project: string,
   title: string,
   update: (
-    lines: Line[],
+    lines: BaseLine[],
     metadata: PatchMetadata,
   ) => string[] | undefined | Promise<string[] | undefined>,
   options?: PatchOptions,

--- a/browser/websocket/updateCodeBlock.ts
+++ b/browser/websocket/updateCodeBlock.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@cosense/types/rest";
+import type { BaseLine } from "@cosense/types/rest";
 import type {
   DeleteChange,
   InsertChange,
@@ -11,8 +11,6 @@ import type { SimpleCodeFile } from "./updateCodeFile.ts";
 import { countBodyIndent, extractFromCodeTitle } from "./_codeBlock.ts";
 import { push, type PushError, type PushOptions } from "./push.ts";
 import type { Result } from "option-t/plain_result";
-
-type Line = Page["lines"][number];
 
 export interface UpdateCodeBlockOptions extends PushOptions {
   /** `true`でデバッグ出力ON */
@@ -35,7 +33,7 @@ export const updateCodeBlock = (
 ): Promise<Result<string, PushError>> => {
   const newCodeBody = getCodeBody(newCode);
   const bodyIndent = countBodyIndent(target);
-  const oldCodeWithoutIndent: Line[] = target.bodyLines.map((e) => {
+  const oldCodeWithoutIndent: BaseLine[] = target.bodyLines.map((e) => {
     return { ...e, text: e.text.slice(bodyIndent) };
   });
 

--- a/browser/websocket/updateCodeFile.ts
+++ b/browser/websocket/updateCodeFile.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@cosense/types/rest";
+import type { BaseLine } from "@cosense/types/rest";
 import type {
   DeleteChange,
   InsertChange,
@@ -10,7 +10,6 @@ import { diff, toExtendedChanges } from "../../deps/onp.ts";
 import { countBodyIndent } from "./_codeBlock.ts";
 import { push, type PushError, type PushOptions } from "./push.ts";
 import type { Result } from "option-t/plain_result";
-type Line = Page["lines"][number];
 
 /** コードブロックの上書きに使う情報のinterface */
 export interface SimpleCodeFile {
@@ -74,7 +73,7 @@ export const updateCodeFile = (
     project,
     title,
     (page) => {
-      const lines: Line[] = page.lines;
+      const lines: BaseLine[] = page.lines;
       const codeBlocks = getCodeBlocks({ project, title, lines }, {
         filename: codeFile.filename,
       });
@@ -104,7 +103,7 @@ export const updateCodeFile = (
 /** TinyCodeBlocksの配列からコード本文をフラットな配列に格納して返す \
  * その際、コードブロックの左側に存在していたインデントは削除する
  */
-const flatCodeBodies = (codeBlocks: readonly TinyCodeBlock[]): Line[] => {
+const flatCodeBodies = (codeBlocks: readonly TinyCodeBlock[]): BaseLine[] => {
   return codeBlocks.map((block) => {
     const indent = countBodyIndent(block);
     return block.bodyLines.map((body) => {
@@ -117,7 +116,7 @@ const flatCodeBodies = (codeBlocks: readonly TinyCodeBlock[]): Line[] => {
 function* makeCommits(
   _codeBlocks: readonly TinyCodeBlock[],
   codeFile: SimpleCodeFile,
-  lines: Line[],
+  lines: BaseLine[],
   { userId, insertPositionIfNotExist, isInsertEmptyLineInTail }: {
     userId: string;
     insertPositionIfNotExist: Required<

--- a/rest/getCodeBlocks.test.ts
+++ b/rest/getCodeBlocks.test.ts
@@ -1,13 +1,12 @@
-import type { Page } from "@cosense/types/rest";
+import type { BaseLine } from "@cosense/types/rest";
 import { assertEquals } from "@std/assert";
 import { assertSnapshot } from "@std/testing/snapshot";
 import { getCodeBlocks } from "./getCodeBlocks.ts";
-type Line = Page["lines"][number];
 
 // https://scrapbox.io/takker/コードブロック記法
 const project = "takker";
 const title = "コードブロック記法";
-const sample: Line[] = [
+const sample: BaseLine[] = [
   {
     "id": "63b7aeeb5defe7001ddae116",
     "text": "コードブロック記法",

--- a/rest/getCodeBlocks.ts
+++ b/rest/getCodeBlocks.ts
@@ -1,9 +1,8 @@
-import type { Page } from "@cosense/types/rest";
+import type { BaseLine } from "@cosense/types/rest";
 import {
   type CodeTitle,
   extractFromCodeTitle,
 } from "../browser/websocket/_codeBlock.ts";
-type Line = Page["lines"][number];
 
 /** pull()から取れる情報で構成したコードブロックの最低限の情報 */
 export interface TinyCodeBlock {
@@ -14,13 +13,13 @@ export interface TinyCodeBlock {
   lang: string;
 
   /** タイトル行 */
-  titleLine: Line;
+  titleLine: BaseLine;
 
   /** コードブロックの中身（タイトル行を含まない） */
-  bodyLines: Line[];
+  bodyLines: BaseLine[];
 
   /** コードブロックの真下の行（無ければ`null`） */
-  nextLine: Line | null;
+  nextLine: BaseLine | null;
 
   /** コードブロックが存在するページの情報 */
   pageInfo: { projectName: string; pageTitle: string };
@@ -46,7 +45,7 @@ export interface GetCodeBlocksFilter {
  * @return コードブロックの配列
  */
 export const getCodeBlocks = (
-  target: { project: string; title: string; lines: Line[] },
+  target: { project: string; title: string; lines: BaseLine[] },
   filter?: GetCodeBlocksFilter,
 ): TinyCodeBlock[] => {
   const codeBlocks: TinyCodeBlock[] = [];


### PR DESCRIPTION
instead of writing `type Line = Page["lines"][number]`