### PR TITLE
refactor(rest): redesign REST API to use ScrapboxResponse

### DIFF
--- a/docs/migration-guide-0.30.0.md
+++ b/docs/migration-guide-0.30.0.md
@@ -1,0 +1,139 @@
+# Migration Guide to v0.30.0
+
+## Breaking Changes
+
+### REST API Changes
+
+The REST API has been completely redesigned to improve type safety, reduce dependencies, and better align with web standards. The main changes are:
+
+1. Removal of `option-t` dependency
+   - All `Result` types from `option-t/plain_result` have been replaced with `ScrapboxResponse`
+   - No more `unwrapOk`, `isErr`, or other option-t utilities
+
+2. New `ScrapboxResponse` class
+   - Extends the web standard `Response` class
+   - Direct access to `body`, `headers`, and other standard Response properties
+   - Type-safe error handling based on HTTP status codes
+   - Built-in JSON parsing with proper typing for success/error cases
+
+### Before and After Examples
+
+#### Before (v0.29.x):
+```typescript
+import { isErr, unwrapOk } from "option-t/plain_result";
+
+const result = await getProfile();
+if (isErr(result)) {
+  console.error("Failed:", result);
+  return;
+}
+const profile = unwrapOk(result);
+console.log("Name:", profile.name);
+```
+
+#### After (v0.30.0):
+```typescript
+const response = await getProfile();
+if (!response.ok) {
+  console.error("Failed:", response.error);
+  return;
+}
+console.log("Name:", response.data.name);
+```
+
+### Key Benefits
+
+1. **Simpler Error Handling**
+   - HTTP status codes determine error types
+   - No need to unwrap results manually
+   - Type-safe error objects with proper typing
+
+2. **Web Standard Compatibility**
+   - Works with standard web APIs without conversion
+   - Direct access to Response properties
+   - Compatible with standard fetch patterns
+
+3. **Better Type Safety**
+   - Response types change based on HTTP status
+   - Proper typing for both success and error cases
+   - No runtime overhead for type checking
+
+### Migration Steps
+
+1. Replace `option-t` imports:
+   ```diff
+   - import { isErr, unwrapOk } from "option-t/plain_result";
+   ```
+
+2. Update error checking:
+   ```diff
+   - if (isErr(result)) {
+   -   console.error(result);
+   + if (!response.ok) {
+   +   console.error(response.error);
+   ```
+
+3. Access response data:
+   ```diff
+   - const data = unwrapOk(result);
+   + const data = response.data;
+   ```
+
+4. For direct Response access:
+   ```typescript
+   // Access headers
+   const contentType = response.headers.get("content-type");
+   
+   // Access raw body
+   const text = await response.text();
+   
+   // Parse JSON with type safety
+   const json = await response.json();
+   ```
+
+### Common Patterns
+
+1. **Status-based Error Handling**:
+```typescript
+const response = await getSnapshot(project, pageId, timestampId);
+
+if (response.status === 422) {
+  // Handle invalid snapshot ID
+  console.error("Invalid snapshot:", response.error);
+  return;
+}
+
+if (!response.ok) {
+  // Handle other errors
+  console.error("Failed:", response.error);
+  return;
+}
+
+// Use the data
+console.log(response.data);
+```
+
+2. **Type-safe JSON Parsing**:
+```typescript
+const response = await getTweetInfo(tweetUrl);
+if (response.ok) {
+  const tweet = response.data;  // Properly typed as TweetInfo
+  console.log(tweet.text);
+}
+```
+
+3. **Working with Headers**:
+```typescript
+const response = await uploadToGCS(file, projectId);
+if (!response.ok && response.headers.get("Content-Type")?.includes("/xml")) {
+  console.error("GCS Error:", await response.text());
+  return;
+}
+```
+
+### Need Help?
+
+If you encounter any issues during migration, please:
+1. Check the examples in this guide
+2. Review the [API documentation](https://jsr.io/@takker/scrapbox-userscript-std)
+3. Open an issue on GitHub if you need further assistance

--- a/rest/auth.ts
+++ b/rest/auth.ts
@@ -1,5 +1,5 @@
-import { createOk, mapForResult, type Result } from "option-t/plain_result";
 import { getProfile } from "./profile.ts";
+import { ScrapboxResponse } from "./response.ts";
 import type { HTTPError } from "./responseIntoResult.ts";
 import type { AbortError, NetworkError } from "./robustFetch.ts";
 import type { ExtendedOptions } from "./options.ts";
@@ -16,11 +16,11 @@ export const cookie = (sid: string): string => `connect.sid=${sid}`;
  */
 export const getCSRFToken = async (
   init?: ExtendedOptions,
-): Promise<Result<string, NetworkError | AbortError | HTTPError>> => {
+): Promise<ScrapboxResponse<string, NetworkError | AbortError | HTTPError>> => {
   // deno-lint-ignore no-explicit-any
   const csrf = init?.csrf ?? (globalThis as any)._csrf;
-  return csrf ? createOk(csrf) : mapForResult(
-    await getProfile(init),
-    (user) => user.csrfToken,
-  );
+  if (csrf) return ScrapboxResponse.ok(csrf);
+
+  const profile = await getProfile(init);
+  return profile.ok ? ScrapboxResponse.ok(profile.data.csrfToken) : profile;
 };

--- a/rest/getWebPageTitle.ts
+++ b/rest/getWebPageTitle.ts
@@ -1,10 +1,3 @@
-import {
-  isErr,
-  mapAsyncForResult,
-  mapErrAsyncForResult,
-  type Result,
-  unwrapOk,
-} from "option-t/plain_result";
 import type {
   BadRequestError,
   InvalidURLError,
@@ -12,7 +5,7 @@ import type {
 } from "@cosense/types/rest";
 import { cookie, getCSRFToken } from "./auth.ts";
 import { parseHTTPError } from "./parseHTTPError.ts";
-import { type HTTPError, responseIntoResult } from "./responseIntoResult.ts";
+import { ScrapboxResponse } from "./response.ts";
 import { type ExtendedOptions, setDefaults } from "./options.ts";
 import type { FetchError } from "./mod.ts";
 
@@ -31,11 +24,11 @@ export type WebPageTitleError =
 export const getWebPageTitle = async (
   url: string | URL,
   init?: ExtendedOptions,
-): Promise<Result<string, WebPageTitleError | FetchError>> => {
+): Promise<ScrapboxResponse<string, WebPageTitleError | FetchError>> => {
   const { sid, hostName, fetch } = setDefaults(init ?? {});
 
-  const csrfResult = await getCSRFToken(init);
-  if (isErr(csrfResult)) return csrfResult;
+  const csrfToken = await getCSRFToken(init);
+  if (!csrfToken.ok) return csrfToken;
 
   const req = new Request(
     `https://${hostName}/api/embed-text/url?url=${
@@ -45,7 +38,7 @@ export const getWebPageTitle = async (
       method: "POST",
       headers: {
         "Content-Type": "application/json;charset=utf-8",
-        "X-CSRF-TOKEN": unwrapOk(csrfResult),
+        "X-CSRF-TOKEN": csrfToken.data,
         ...(sid ? { Cookie: cookie(sid) } : {}),
       },
       body: JSON.stringify({ timeout: 3000 }),
@@ -53,21 +46,18 @@ export const getWebPageTitle = async (
   );
 
   const res = await fetch(req);
-  if (isErr(res)) return res;
+  const response = ScrapboxResponse.from<string, WebPageTitleError>(res);
 
-  return mapAsyncForResult(
-    await mapErrAsyncForResult(
-      responseIntoResult(unwrapOk(res)),
-      async (error) =>
-        (await parseHTTPError(error, [
-          "SessionError",
-          "BadRequestError",
-          "InvalidURLError",
-        ])) ?? error,
-    ),
-    async (res) => {
-      const { title } = (await res.json()) as { title: string };
-      return title;
-    },
-  );
+  await parseHTTPError(response, [
+    "SessionError",
+    "BadRequestError",
+    "InvalidURLError",
+  ]);
+
+  if (response.ok) {
+    const { title } = await response.json() as { title: string };
+    return ScrapboxResponse.ok(title);
+  }
+
+  return response;
 };

--- a/rest/pages.ts
+++ b/rest/pages.ts
@@ -10,14 +10,7 @@ import { cookie } from "./auth.ts";
 import { parseHTTPError } from "./parseHTTPError.ts";
 import { encodeTitleURI } from "../title.ts";
 import { type BaseOptions, setDefaults } from "./options.ts";
-import {
-  andThenAsyncForResult,
-  mapAsyncForResult,
-  mapErrAsyncForResult,
-  type Result,
-} from "option-t/plain_result";
-import { unwrapOrForMaybe } from "option-t/maybe";
-import { type HTTPError, responseIntoResult } from "./responseIntoResult.ts";
+import { ScrapboxResponse } from "./response.ts";
 import type { FetchError } from "./robustFetch.ts";
 
 /** Options for `getPage()` */
@@ -53,39 +46,31 @@ const getPage_toRequest: GetPage["toRequest"] = (
   );
 };
 
-const getPage_fromResponse: GetPage["fromResponse"] = async (res) =>
-  mapErrAsyncForResult(
-    await mapAsyncForResult(
-      responseIntoResult(res),
-      (res) => res.json() as Promise<Page>,
-    ),
-    async (
-      error,
-    ) => {
-      if (error.response.status === 414) {
-        return {
-          name: "TooLongURIError",
-          message: "project ids may be too much.",
-        };
-      }
+const getPage_fromResponse: GetPage["fromResponse"] = async (res) => {
+  const response = ScrapboxResponse.from<Page, PageError>(res);
+  
+  if (response.status === 414) {
+    return ScrapboxResponse.error({
+      name: "TooLongURIError",
+      message: "project ids may be too much.",
+    });
+  }
 
-      return unwrapOrForMaybe<PageError>(
-        await parseHTTPError(error, [
-          "NotFoundError",
-          "NotLoggedInError",
-          "NotMemberError",
-        ]),
-        error,
-      );
-    },
-  );
+  await parseHTTPError(response, [
+    "NotFoundError",
+    "NotLoggedInError",
+    "NotMemberError",
+  ]);
+
+  return response;
+};
 
 export interface GetPage {
-  /** /api/pages/:project/:title の要求を組み立てる
+  /** Build request for /api/pages/:project/:title
    *
-   * @param project 取得したいページのproject名
-   * @param title 取得したいページのtitle 大文字小文字は問わない
-   * @param options オプション
+   * @param project Project name to get page from
+   * @param title Page title (case insensitive)
+   * @param options Additional options
    * @return request
    */
   toRequest: (
@@ -94,18 +79,18 @@ export interface GetPage {
     options?: GetPageOption,
   ) => Request;
 
-  /** 帰ってきた応答からページのJSONデータを取得する
+  /** Get page JSON data from response
    *
-   * @param res 応答
-   * @return ページのJSONデータ
+   * @param res Response object
+   * @return Page JSON data
    */
-  fromResponse: (res: Response) => Promise<Result<Page, PageError>>;
+  fromResponse: (res: Response) => Promise<ScrapboxResponse<Page, PageError>>;
 
   (
     project: string,
     title: string,
     options?: GetPageOption,
-  ): Promise<Result<Page, PageError | FetchError>>;
+  ): Promise<ScrapboxResponse<Page, PageError | FetchError>>;
 }
 
 export type PageError =
@@ -126,13 +111,12 @@ export const getPage: GetPage = /* @__PURE__ */ (() => {
     project,
     title,
     options,
-  ) =>
-    andThenAsyncForResult<Response, Page, PageError | FetchError>(
-      await setDefaults(options ?? {}).fetch(
-        getPage_toRequest(project, title, options),
-      ),
-      (input) => getPage_fromResponse(input),
+  ) => {
+    const response = await setDefaults(options ?? {}).fetch(
+      getPage_toRequest(project, title, options),
     );
+    return getPage_fromResponse(response);
+  };
 
   fn.toRequest = getPage_toRequest;
   fn.fromResponse = getPage_fromResponse;
@@ -168,10 +152,10 @@ export interface ListPagesOption extends BaseOptions {
 }
 
 export interface ListPages {
-  /** /api/pages/:project の要求を組み立てる
+  /** Build request for /api/pages/:project
    *
-   * @param project 取得したいページのproject名
-   * @param options オプション
+   * @param project Project name to list pages from
+   * @param options Additional options
    * @return request
    */
   toRequest: (
@@ -179,17 +163,17 @@ export interface ListPages {
     options?: ListPagesOption,
   ) => Request;
 
-  /** 帰ってきた応答からページのJSONデータを取得する
+  /** Get page list JSON data from response
    *
-   * @param res 応答
-   * @return ページのJSONデータ
+   * @param res Response object
+   * @return Page list JSON data
    */
-  fromResponse: (res: Response) => Promise<Result<PageList, ListPagesError>>;
+  fromResponse: (res: Response) => Promise<ScrapboxResponse<PageList, ListPagesError>>;
 
   (
     project: string,
     options?: ListPagesOption,
-  ): Promise<Result<PageList, ListPagesError | FetchError>>;
+  ): Promise<ScrapboxResponse<PageList, ListPagesError | FetchError>>;
 }
 
 export type ListPagesError =
@@ -213,22 +197,17 @@ const listPages_toRequest: ListPages["toRequest"] = (project, options) => {
   );
 };
 
-const listPages_fromResponse: ListPages["fromResponse"] = async (res) =>
-  mapErrAsyncForResult(
-    await mapAsyncForResult(
-      responseIntoResult(res),
-      (res) => res.json() as Promise<PageList>,
-    ),
-    async (error) =>
-      unwrapOrForMaybe<ListPagesError>(
-        await parseHTTPError(error, [
-          "NotFoundError",
-          "NotLoggedInError",
-          "NotMemberError",
-        ]),
-        error,
-      ),
-  );
+const listPages_fromResponse: ListPages["fromResponse"] = async (res) => {
+  const response = ScrapboxResponse.from<PageList, ListPagesError>(res);
+  
+  await parseHTTPError(response, [
+    "NotFoundError",
+    "NotLoggedInError",
+    "NotMemberError",
+  ]);
+
+  return response;
+};
 
 /** 指定したprojectのページを一覧する
  *
@@ -239,13 +218,12 @@ export const listPages: ListPages = /* @__PURE__ */ (() => {
   const fn: ListPages = async (
     project,
     options?,
-  ) =>
-    andThenAsyncForResult<Response, PageList, ListPagesError | FetchError>(
-      await setDefaults(options ?? {})?.fetch(
-        listPages_toRequest(project, options),
-      ),
-      listPages_fromResponse,
+  ) => {
+    const response = await setDefaults(options ?? {})?.fetch(
+      listPages_toRequest(project, options),
     );
+    return listPages_fromResponse(response);
+  };
 
   fn.toRequest = listPages_toRequest;
   fn.fromResponse = listPages_fromResponse;

--- a/rest/parseHTTPError.ts
+++ b/rest/parseHTTPError.ts
@@ -8,13 +8,11 @@ import type {
   NotPrivilegeError,
   SessionError,
 } from "@cosense/types/rest";
-import type { Maybe } from "option-t/maybe";
 import { isArrayOf } from "@core/unknownutil/is/array-of";
 import { isLiteralOneOf } from "@core/unknownutil/is/literal-one-of";
 import { isRecord } from "@core/unknownutil/is/record";
 import { isString } from "@core/unknownutil/is/string";
-
-import type { HTTPError } from "./responseIntoResult.ts";
+import type { ScrapboxResponse } from "./response.ts";
 
 export interface RESTfullAPIErrorMap {
   BadRequestError: BadRequestError;
@@ -27,20 +25,22 @@ export interface RESTfullAPIErrorMap {
   NotPrivilegeError: NotPrivilegeError;
 }
 
-/** 失敗した要求からエラー情報を取り出す */
+/** Extract error information from a failed request */
 export const parseHTTPError = async <
   ErrorNames extends keyof RESTfullAPIErrorMap,
+  T = unknown,
+  E = unknown,
 >(
-  error: HTTPError,
+  response: ScrapboxResponse<T, E>,
   errorNames: ErrorNames[],
-): Promise<Maybe<RESTfullAPIErrorMap[ErrorNames]>> => {
-  const res = error.response.clone();
+): Promise<RESTfullAPIErrorMap[ErrorNames] | undefined> => {
+  const res = response.clone();
   const isErrorNames = isLiteralOneOf(errorNames);
   try {
     const json: unknown = await res.json();
-    if (!isRecord(json)) return;
+    if (!isRecord(json)) return undefined;
     if (res.status === 422) {
-      if (!isString(json.message)) return;
+      if (!isString(json.message)) return undefined;
       for (
         const name of [
           "NoQueryError",
@@ -48,34 +48,40 @@ export const parseHTTPError = async <
         ] as (keyof RESTfullAPIErrorMap)[]
       ) {
         if (!(errorNames as string[]).includes(name)) continue;
-        return {
+        const error = {
           name,
           message: json.message,
-        } as unknown as RESTfullAPIErrorMap[ErrorNames];
+        } as RESTfullAPIErrorMap[ErrorNames];
+        Object.assign(response, { error });
+        return error;
       }
     }
-    if (!isErrorNames(json.name)) return;
-    if (!isString(json.message)) return;
+    if (!isErrorNames(json.name)) return undefined;
+    if (!isString(json.message)) return undefined;
     if (json.name === "NotLoggedInError") {
-      if (!isRecord(json.detals)) return;
-      if (!isString(json.detals.project)) return;
-      if (!isArrayOf(isLoginStrategies)(json.detals.loginStrategies)) return;
-      return {
+      if (!isRecord(json.detals)) return undefined;
+      if (!isString(json.detals.project)) return undefined;
+      if (!isArrayOf(isLoginStrategies)(json.detals.loginStrategies)) return undefined;
+      const error = {
         name: json.name,
         message: json.message,
         details: {
           project: json.detals.project,
           loginStrategies: json.detals.loginStrategies,
         },
-      } as unknown as RESTfullAPIErrorMap[ErrorNames];
+      } as RESTfullAPIErrorMap[ErrorNames];
+      Object.assign(response, { error });
+      return error;
     }
-    return {
+    const error = {
       name: json.name,
       message: json.message,
-    } as unknown as RESTfullAPIErrorMap[ErrorNames];
+    } as RESTfullAPIErrorMap[ErrorNames];
+    Object.assign(response, { error });
+    return error;
   } catch (e: unknown) {
-    if (e instanceof SyntaxError) return;
-    // JSONのparse error以外はそのまま投げる
+    if (e instanceof SyntaxError) return undefined;
+    // Re-throw non-JSON parse errors
     throw e;
   }
 };

--- a/rest/profile.ts
+++ b/rest/profile.ts
@@ -1,36 +1,30 @@
-import {
-  isErr,
-  mapAsyncForResult,
-  type Result,
-  unwrapOk,
-} from "option-t/plain_result";
 import type { GuestUser, MemberUser } from "@cosense/types/rest";
 import { cookie } from "./auth.ts";
-import { type HTTPError, responseIntoResult } from "./responseIntoResult.ts";
+import { ScrapboxResponse } from "./response.ts";
 import type { FetchError } from "./robustFetch.ts";
 import { type BaseOptions, setDefaults } from "./options.ts";
 
 export interface GetProfile {
-  /** /api/users/me の要求を組み立てる
+  /** Build request for /api/users/me
    *
    * @param init connect.sid etc.
    * @return request
    */
   toRequest: (init?: BaseOptions) => Request;
 
-  /** get the user profile from the given response
+  /** Get user profile from response
    *
-   * @param res response
-   * @return user profile
+   * @param res Response object
+   * @return User profile
    */
   fromResponse: (
     res: Response,
   ) => Promise<
-    Result<MemberUser | GuestUser, ProfileError>
+    ScrapboxResponse<MemberUser | GuestUser, ProfileError>
   >;
 
   (init?: BaseOptions): Promise<
-    Result<MemberUser | GuestUser, ProfileError | FetchError>
+    ScrapboxResponse<MemberUser | GuestUser, ProfileError | FetchError>
   >;
 }
 
@@ -46,20 +40,17 @@ const getProfile_toRequest: GetProfile["toRequest"] = (
   );
 };
 
-const getProfile_fromResponse: GetProfile["fromResponse"] = (response) =>
-  mapAsyncForResult(
-    responseIntoResult(response),
-    async (res) => (await res.json()) as MemberUser | GuestUser,
-  );
+const getProfile_fromResponse: GetProfile["fromResponse"] = async (res) => {
+  const response = ScrapboxResponse.from<MemberUser | GuestUser, ProfileError>(res);
+  return response;
+};
 
 export const getProfile: GetProfile = /* @__PURE__ */ (() => {
   const fn: GetProfile = async (init) => {
     const { fetch, ...rest } = setDefaults(init ?? {});
 
-    const resResult = await fetch(getProfile_toRequest(rest));
-    return isErr(resResult)
-      ? resResult
-      : getProfile_fromResponse(unwrapOk(resResult));
+    const response = await fetch(getProfile_toRequest(rest));
+    return getProfile_fromResponse(response);
   };
 
   fn.toRequest = getProfile_toRequest;

--- a/rest/replaceLinks.ts
+++ b/rest/replaceLinks.ts
@@ -1,10 +1,3 @@
-import {
-  isErr,
-  mapAsyncForResult,
-  mapErrAsyncForResult,
-  type Result,
-  unwrapOk,
-} from "option-t/plain_result";
 import type {
   NotFoundError,
   NotLoggedInError,
@@ -12,7 +5,7 @@ import type {
 } from "@cosense/types/rest";
 import { cookie, getCSRFToken } from "./auth.ts";
 import { parseHTTPError } from "./parseHTTPError.ts";
-import { type HTTPError, responseIntoResult } from "./responseIntoResult.ts";
+import { ScrapboxResponse } from "./response.ts";
 import type { FetchError } from "./robustFetch.ts";
 import { type ExtendedOptions, setDefaults } from "./options.ts";
 
@@ -38,11 +31,11 @@ export const replaceLinks = async (
   from: string,
   to: string,
   init?: ExtendedOptions,
-): Promise<Result<number, ReplaceLinksError | FetchError>> => {
+): Promise<ScrapboxResponse<number, ReplaceLinksError | FetchError>> => {
   const { sid, hostName, fetch } = setDefaults(init ?? {});
 
-  const csrfResult = await getCSRFToken(init);
-  if (isErr(csrfResult)) return csrfResult;
+  const csrfToken = await getCSRFToken(init);
+  if (!csrfToken.ok) return csrfToken;
 
   const req = new Request(
     `https://${hostName}/api/pages/${project}/replace/links`,
@@ -50,30 +43,27 @@ export const replaceLinks = async (
       method: "POST",
       headers: {
         "Content-Type": "application/json;charset=utf-8",
-        "X-CSRF-TOKEN": unwrapOk(csrfResult),
+        "X-CSRF-TOKEN": csrfToken.data,
         ...(sid ? { Cookie: cookie(sid) } : {}),
       },
       body: JSON.stringify({ from, to }),
     },
   );
 
-  const resResult = await fetch(req);
-  if (isErr(resResult)) return resResult;
+  const res = await fetch(req);
+  const response = ScrapboxResponse.from<number, ReplaceLinksError>(res);
 
-  return mapAsyncForResult(
-    await mapErrAsyncForResult(
-      responseIntoResult(unwrapOk(resResult)),
-      async (error) =>
-        (await parseHTTPError(error, [
-          "NotFoundError",
-          "NotLoggedInError",
-          "NotMemberError",
-        ])) ?? error,
-    ),
-    async (res) => {
-      // messageには"2 pages have been successfully updated!"というような文字列が入っているはず
-      const { message } = (await res.json()) as { message: string };
-      return parseInt(message.match(/\d+/)?.[0] ?? "0");
-    },
-  );
+  await parseHTTPError(response, [
+    "NotFoundError",
+    "NotLoggedInError",
+    "NotMemberError",
+  ]);
+
+  if (response.ok) {
+    // The message contains text like "2 pages have been successfully updated!"
+    const { message } = await response.json() as { message: string };
+    return ScrapboxResponse.ok(parseInt(message.match(/\d+/)?.[0] ?? "0"));
+  }
+
+  return response;
 };

--- a/rest/response.ts
+++ b/rest/response.ts
@@ -1,0 +1,105 @@
+import type {
+  BadRequestError,
+  InvalidURLError,
+  NoQueryError,
+  NotFoundError,
+  NotLoggedInError,
+  NotMemberError,
+  NotPrivilegeError,
+  SessionError,
+} from "@cosense/types/rest";
+
+/**
+ * A type-safe response class that extends the web standard Response.
+ * It provides status-based type switching and direct access to Response properties.
+ */
+export class ScrapboxResponse<T = unknown, E = unknown> extends Response {
+  error?: E;
+
+  constructor(response: Response) {
+    super(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  }
+
+  /**
+   * Parse the response body as JSON with type safety based on status code.
+   * Returns T for successful responses (2xx) and E for error responses.
+   */
+  async json(): Promise<T> {
+    const data = await super.json();
+    return data as T;
+  }
+
+  /**
+   * Create a new ScrapboxResponse instance from a Response.
+   */
+  static from<T = unknown, E = unknown>(response: Response): ScrapboxResponse<T, E> {
+    if (response instanceof ScrapboxResponse) {
+      return response;
+    }
+    return new ScrapboxResponse<T, E>(response);
+  }
+
+  /**
+   * Create a new error response with the given error details.
+   */
+  static error<T = unknown, E = unknown>(
+    error: E,
+    init?: ResponseInit,
+  ): ScrapboxResponse<T, E> {
+    const response = new ScrapboxResponse<T, E>(
+      new Response(null, {
+        status: 400,
+        ...init,
+      }),
+    );
+    Object.assign(response, { error });
+    return response;
+  }
+
+  /**
+   * Create a new success response with the given data.
+   */
+  static success<T = unknown, E = unknown>(
+    data: T,
+    init?: ResponseInit,
+  ): ScrapboxResponse<T, E> {
+    return new ScrapboxResponse<T, E>(
+      new Response(JSON.stringify(data), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        ...init,
+      }),
+    );
+  }
+
+  /**
+   * Clone the response while preserving type information and error details.
+   */
+  clone(): ScrapboxResponse<T, E> {
+    const cloned = super.clone();
+    const response = new ScrapboxResponse<T, E>(cloned);
+    if (this.error) {
+      Object.assign(response, { error: this.error });
+    }
+    return response;
+  }
+}
+
+export type ScrapboxErrorResponse<E> = ScrapboxResponse<never, E>;
+export type ScrapboxSuccessResponse<T> = ScrapboxResponse<T, never>;
+
+export type RESTError =
+  | BadRequestError
+  | NotFoundError
+  | NotLoggedInError
+  | NotMemberError
+  | SessionError
+  | InvalidURLError
+  | NoQueryError
+  | NotPrivilegeError;

--- a/rest/search.ts
+++ b/rest/search.ts
@@ -1,10 +1,3 @@
-import {
-  isErr,
-  mapAsyncForResult,
-  mapErrAsyncForResult,
-  type Result,
-  unwrapOk,
-} from "option-t/plain_result";
 import type {
   NoQueryError,
   NotFoundError,
@@ -15,7 +8,7 @@ import type {
 } from "@cosense/types/rest";
 import { cookie } from "./auth.ts";
 import { parseHTTPError } from "./parseHTTPError.ts";
-import { type HTTPError, responseIntoResult } from "./responseIntoResult.ts";
+import { ScrapboxResponse } from "./response.ts";
 import { type BaseOptions, setDefaults } from "./options.ts";
 import type { FetchError } from "./mod.ts";
 
@@ -36,7 +29,7 @@ export const searchForPages = async (
   query: string,
   project: string,
   init?: BaseOptions,
-): Promise<Result<SearchResult, SearchForPagesError | FetchError>> => {
+): Promise<ScrapboxResponse<SearchResult, SearchForPagesError | FetchError>> => {
   const { sid, hostName, fetch } = setDefaults(init ?? {});
 
   const req = new Request(
@@ -47,21 +40,16 @@ export const searchForPages = async (
   );
 
   const res = await fetch(req);
-  if (isErr(res)) return res;
+  const response = ScrapboxResponse.from<SearchResult, SearchForPagesError>(res);
 
-  return mapAsyncForResult(
-    await mapErrAsyncForResult(
-      responseIntoResult(unwrapOk(res)),
-      async (error) =>
-        (await parseHTTPError(error, [
-          "NotFoundError",
-          "NotLoggedInError",
-          "NotMemberError",
-          "NoQueryError",
-        ])) ?? error,
-    ),
-    (res) => res.json() as Promise<SearchResult>,
-  );
+  await parseHTTPError(response, [
+    "NotFoundError",
+    "NotLoggedInError",
+    "NotMemberError",
+    "NoQueryError",
+  ]);
+
+  return response;
 };
 
 export type SearchForJoinedProjectsError =
@@ -78,7 +66,7 @@ export const searchForJoinedProjects = async (
   query: string,
   init?: BaseOptions,
 ): Promise<
-  Result<
+  ScrapboxResponse<
     ProjectSearchResult,
     SearchForJoinedProjectsError | FetchError
   >
@@ -93,19 +81,14 @@ export const searchForJoinedProjects = async (
   );
 
   const res = await fetch(req);
-  if (isErr(res)) return res;
+  const response = ScrapboxResponse.from<ProjectSearchResult, SearchForJoinedProjectsError>(res);
 
-  return mapAsyncForResult(
-    await mapErrAsyncForResult(
-      responseIntoResult(unwrapOk(res)),
-      async (error) =>
-        (await parseHTTPError(error, [
-          "NotLoggedInError",
-          "NoQueryError",
-        ])) ?? error,
-    ),
-    (res) => res.json() as Promise<ProjectSearchResult>,
-  );
+  await parseHTTPError(response, [
+    "NotLoggedInError",
+    "NoQueryError",
+  ]);
+
+  return response;
 };
 
 export type SearchForWatchListError = SearchForJoinedProjectsError;
@@ -125,7 +108,7 @@ export const searchForWatchList = async (
   projectIds: string[],
   init?: BaseOptions,
 ): Promise<
-  Result<
+  ScrapboxResponse<
     ProjectSearchResult,
     SearchForWatchListError | FetchError
   >
@@ -143,17 +126,12 @@ export const searchForWatchList = async (
   );
 
   const res = await fetch(req);
-  if (isErr(res)) return res;
+  const response = ScrapboxResponse.from<ProjectSearchResult, SearchForWatchListError>(res);
 
-  return mapAsyncForResult(
-    await mapErrAsyncForResult(
-      responseIntoResult(unwrapOk(res)),
-      async (error) =>
-        (await parseHTTPError(error, [
-          "NotLoggedInError",
-          "NoQueryError",
-        ])) ?? error,
-    ),
-    (res) => res.json() as Promise<ProjectSearchResult>,
-  );
+  await parseHTTPError(response, [
+    "NotLoggedInError",
+    "NoQueryError",
+  ]);
+
+  return response;
 };


### PR DESCRIPTION
BREAKING CHANGE: Replace option-t Result with ScrapboxResponse

- Remove option-t dependency
- Add ScrapboxResponse class extending web standard Response
- Improve type safety with status-based type switching
- Allow direct access to Response.body and headers
- Add migration guide for v0.30.0

This change follows the implementation pattern from @takker/gyazo@0.4.0 and prepares for release as version 0.30.0.

Resolves #213