### PR TITLE
refactor(api): remove namespace exports and use unique identifiers for API methods

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -1,50 +1,5 @@
-export * as pages from "./api/pages.ts";
-export * as projects from "./api/projects.ts";
-export * as users from "./api/users.ts";
+export * from "./api/pages.ts";
+export * from "./api/projects.ts";
+export * from "./api/users.ts";
 export type { HTTPError, TypedError } from "./error.ts";
 export type { BaseOptions, ExtendedOptions, OAuthOptions } from "./util.ts";
-
-export {
-  get as listPages,
-  list as listPagesStream,
-  type ListPagesOption,
-  type ListPagesStreamOption,
-  makeGetRequest as makeListPagesRequest,
-} from "./api/pages/project.ts";
-export {
-  makePostRequest as makeReplaceLinksRequest,
-  post as replaceLinks,
-} from "./api/pages/project/replace/links.ts";
-export {
-  get as searchForPages,
-  makeGetRequest as makeSearchForPagesRequest,
-} from "./api/pages/project/search/query.ts";
-export {
-  get as getLinks,
-  type GetLinksOptions,
-  list as readLinks,
-  makeGetRequest as makeGetLinksRequest,
-} from "./api/pages/project/search/titles.ts";
-export {
-  get as getPage,
-  type GetPageOption,
-  makeGetRequest as makeGetPageRequest,
-} from "./api/pages/project/title.ts";
-export {
-  get as getText,
-  type GetTextOption,
-  makeGetRequest as makeGetTextRequest,
-} from "./api/pages/project/title/text.ts";
-export {
-  get as getIcon,
-  type GetIconOption,
-  makeGetRequest as makeGetIconRequest,
-} from "./api/pages/project/title/icon.ts";
-export {
-  get as getProject,
-  makeGetRequest as makeGetProjectRequest,
-} from "./api/projects/project.ts";
-export {
-  get as getUser,
-  makeGetRequest as makeGetUserRequest,
-} from "./api/users/me.ts";

--- a/api/pages.ts
+++ b/api/pages.ts
@@ -1,1 +1,1 @@
-export * as project from "./pages/project.ts";
+export * from "./pages/project.ts";

--- a/api/pages/project.ts
+++ b/api/pages/project.ts
@@ -21,7 +21,7 @@ import { pooledMap } from "@std/async/pool";
 import { range } from "@core/iterutil/range";
 import { flatten } from "@core/iterutil/async/flatten";
 
-/** Options for {@linkcode get}
+/** Options for {@linkcode listPages}
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */
@@ -102,7 +102,7 @@ export const makeGetRequest = <R extends Response | undefined>(
  *            - {@linkcode NotLoggedInError}: Authentication required
  *            - {@linkcode NotMemberError}: User lacks access
  */
-export const get = <R extends Response | undefined = Response>(
+export const listPages = <R extends Response | undefined = Response>(
   project: string,
   options?: ListPagesOption<R>,
 ): Promise<
@@ -125,7 +125,7 @@ export const get = <R extends Response | undefined = Response>(
   >;
 
 /**
- * Options for {@linkcode list}
+ * Options for {@linkcode listPagesStream}
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */
@@ -147,7 +147,7 @@ export interface ListPagesStreamOption<R extends Response | undefined>
  * @param options Configuration options for pagination and sorting
  * @throws {HTTPError | TypedError<"NotLoggedInError" | "NotMemberError" | "NotFoundError">} If any requests in the pagination sequence fail
  */
-export async function* list(
+export async function* listPagesStream(
   project: string,
   options?: ListPagesStreamOption<Response>,
 ): AsyncGenerator<BasePage, void, unknown> {
@@ -156,7 +156,7 @@ export async function* list(
     skip: options?.skip ?? 0,
     limit: options?.limit ?? 100,
   };
-  const response = await ensureResponse(await get(project, props));
+  const response = await ensureResponse(await listPages(project, props));
   const list = await response.json();
   yield* list.pages;
 
@@ -170,7 +170,7 @@ export async function* list(
       range(0, times - 1),
       async (i) => {
         const response = await ensureResponse(
-          await get(project, { ...props, skip: skip + i * limit, limit }),
+          await listPages(project, { ...props, skip: skip + i * limit, limit }),
         );
         const list = await response.json();
         return list.pages;
@@ -203,6 +203,6 @@ const ensureResponse = async (
   }
 };
 
-export * as replace from "./project/replace.ts";
-export * as search from "./project/search.ts";
-export * as title from "./project/title.ts";
+export * from "./project/replace.ts";
+export * from "./project/search.ts";
+export * from "./project/title.ts";

--- a/api/pages/project/replace.ts
+++ b/api/pages/project/replace.ts
@@ -1,1 +1,1 @@
-export * as links from "./replace/links.ts";
+export * from "./replace/links.ts";

--- a/api/pages/project/replace/links.ts
+++ b/api/pages/project/replace/links.ts
@@ -6,7 +6,7 @@ import type {
 import type { ResponseOfEndpoint } from "../../../../targeted_response.ts";
 import { type ExtendedOptions, setDefaults } from "../../../../util.ts";
 import { cookie } from "../../../../rest/auth.ts";
-import { get } from "../../../users/me.ts";
+import { getUser } from "../../../users/me.ts";
 
 /** Constructs a request for the `/api/pages/:project/replace/links` endpoint
  *
@@ -18,7 +18,7 @@ import { get } from "../../../users/me.ts";
  * @param init - Additional configuration options
  * @returns A {@linkcode Request} object for replacing links in `project`
  */
-export const makePostRequest = <R extends Response | undefined>(
+export const makeReplaceLinksRequest = <R extends Response | undefined>(
   project: string,
   from: string,
   to: string,
@@ -55,7 +55,7 @@ export const makePostRequest = <R extends Response | undefined>(
  *            - {@linkcode NotLoggedInError}: Authentication required
  *            - {@linkcode NotMemberError}: User lacks access
  */
-export const post = async <R extends Response | undefined = Response>(
+export const replaceLinks = async <R extends Response | undefined = Response>(
   project: string,
   from: string,
   to: string,
@@ -71,13 +71,13 @@ export const post = async <R extends Response | undefined = Response>(
   let { csrf, fetch, ...init2 } = setDefaults(init ?? {});
 
   if (!csrf) {
-    const res = await get(init2);
+    const res = await getUser(init2);
     if (!res.ok) return res;
     csrf = (await res.json()).csrfToken;
   }
 
   return fetch(
-    makePostRequest(project, from, to, { csrf, ...init2 }),
+    makeReplaceLinksRequest(project, from, to, { csrf, ...init2 }),
   ) as Promise<
     ResponseOfEndpoint<{
       200: string;

--- a/api/pages/project/search.ts
+++ b/api/pages/project/search.ts
@@ -1,2 +1,2 @@
-export * as query from "./search/query.ts";
-export * as titles from "./search/titles.ts";
+export * from "./search/query.ts";
+export * from "./search/titles.ts";

--- a/api/pages/project/search/query.ts
+++ b/api/pages/project/search/query.ts
@@ -17,7 +17,7 @@ import { cookie } from "../../../../rest/auth.ts";
  * @param options - Additional configuration options
  * @returns A {@linkcode Request} object for fetching page data
  */
-export const makeGetRequest = <R extends Response | undefined>(
+export const makeSearchForPagesRequest = <R extends Response | undefined>(
   project: string,
   query: string,
   options?: BaseOptions<R>,
@@ -41,7 +41,7 @@ export const makeGetRequest = <R extends Response | undefined>(
  * @param options Additional configuration options for the request
  * @returns A {@linkcode Response} object containing the search results
  */
-export const get = <R extends Response | undefined = Response>(
+export const searchForPages = <R extends Response | undefined = Response>(
   project: string,
   query: string,
   options?: BaseOptions<R>,
@@ -55,7 +55,7 @@ export const get = <R extends Response | undefined = Response>(
   }, R>
 > =>
   setDefaults(options ?? {}).fetch(
-    makeGetRequest(project, query, options),
+    makeSearchForPagesRequest(project, query, options),
   ) as Promise<
     ResponseOfEndpoint<{
       200: SearchResult;

--- a/api/pages/project/title.ts
+++ b/api/pages/project/title.ts
@@ -32,7 +32,7 @@ export interface GetPageOption<R extends Response | undefined>
  * @param options - Additional configuration options
  * @returns A {@linkcode Request} object for fetching page data
  */
-export const makeGetRequest = <R extends Response | undefined>(
+export const makeGetPageRequest = <R extends Response | undefined>(
   project: string,
   title: string,
   options?: GetPageOption<R>,
@@ -64,7 +64,7 @@ export const makeGetRequest = <R extends Response | undefined>(
  *            - {@linkcode NotLoggedInError}: Authentication required
  *            - {@linkcode NotMemberError}: User lacks access
  */
-export const get = <R extends Response | undefined = Response>(
+export const getPage = <R extends Response | undefined = Response>(
   project: string,
   title: string,
   options?: GetPageOption<R>,
@@ -77,7 +77,7 @@ export const get = <R extends Response | undefined = Response>(
   }, R>
 > =>
   setDefaults(options ?? {}).fetch(
-    makeGetRequest(project, title, options),
+    makeGetPageRequest(project, title, options),
   ) as Promise<
     ResponseOfEndpoint<{
       200: Page;
@@ -87,5 +87,5 @@ export const get = <R extends Response | undefined = Response>(
     }, R>
   >;
 
-export * as text from "./title/text.ts";
-export * as icon from "./title/icon.ts";
+export * from "./title/text.ts";
+export * from "./title/icon.ts";

--- a/api/pages/project/title/icon.ts
+++ b/api/pages/project/title/icon.ts
@@ -9,7 +9,7 @@ import { encodeTitleURI } from "../../../../title.ts";
 import { cookie } from "../../../../rest/auth.ts";
 
 /**
- * Options for {@linkcode get}
+ * Options for {@linkcode getIcon}
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */
@@ -28,7 +28,7 @@ export interface GetIconOption<R extends Response | undefined>
  * @param options - Additional configuration options
  * @returns A {@linkcode Request} object for fetching page data
  */
-export const makeGetRequest = <R extends Response | undefined>(
+export const makeGetIconRequest = <R extends Response | undefined>(
   project: string,
   title: string,
   options?: GetIconOption<R>,
@@ -52,7 +52,7 @@ export const makeGetRequest = <R extends Response | undefined>(
  * @param options Additional configuration options for the request
  * @returns A {@linkcode Response} object containing the page image
  */
-export const get = <R extends Response | undefined = Response>(
+export const getIcon = <R extends Response | undefined = Response>(
   project: string,
   title: string,
   options?: GetIconOption<R>,
@@ -65,7 +65,7 @@ export const get = <R extends Response | undefined = Response>(
   }, R>
 > =>
   setDefaults(options ?? {}).fetch(
-    makeGetRequest(project, title, options),
+    makeGetIconRequest(project, title, options),
   ) as Promise<
     ResponseOfEndpoint<{
       200: Blob;

--- a/api/pages/project/title/text.ts
+++ b/api/pages/project/title/text.ts
@@ -9,7 +9,7 @@ import { encodeTitleURI } from "../../../../title.ts";
 import { cookie } from "../../../../rest/auth.ts";
 
 /**
- * Options for {@linkcode get}
+ * Options for {@linkcode getText}
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */
@@ -28,7 +28,7 @@ export interface GetTextOption<R extends Response | undefined>
  * @param options - Additional configuration options
  * @returns A {@linkcode Request} object for fetching page data
  */
-export const makeGetRequest = <R extends Response | undefined>(
+export const makeGetTextRequest = <R extends Response | undefined>(
   project: string,
   title: string,
   options?: GetTextOption<R>,
@@ -52,7 +52,7 @@ export const makeGetRequest = <R extends Response | undefined>(
  * @param options Additional configuration options for the request
  * @returns A {@linkcode Response} object containing the page text
  */
-export const get = <R extends Response | undefined = Response>(
+export const getText = <R extends Response | undefined = Response>(
   project: string,
   title: string,
   options?: GetTextOption<R>,
@@ -65,7 +65,7 @@ export const get = <R extends Response | undefined = Response>(
   }, R>
 > =>
   setDefaults(options ?? {}).fetch(
-    makeGetRequest(project, title, options),
+    makeGetTextRequest(project, title, options),
   ) as Promise<
     ResponseOfEndpoint<{
       200: string;

--- a/api/projects.ts
+++ b/api/projects.ts
@@ -1,1 +1,1 @@
-export * as project from "./projects/project.ts";
+export * from "./projects/project.ts";

--- a/api/projects/project.ts
+++ b/api/projects/project.ts
@@ -17,7 +17,7 @@ import { cookie } from "../../rest/auth.ts";
  * @param options - Additional configuration options
  * @returns A {@linkcode Request} object for fetching project data
  */
-export const makeGetRequest = <R extends Response | undefined>(
+export const makeGetProjectRequest = <R extends Response | undefined>(
   project: string,
   options?: BaseOptions<R>,
 ): Request => {
@@ -41,7 +41,7 @@ export const makeGetRequest = <R extends Response | undefined>(
  * @param options Additional configuration options for the request
  * @returns A {@linkcode Response} object containing the project data
  */
-export const get = <R extends Response | undefined = Response>(
+export const getProject = <R extends Response | undefined = Response>(
   project: string,
   options?: BaseOptions<R>,
 ): Promise<
@@ -53,7 +53,7 @@ export const get = <R extends Response | undefined = Response>(
   }, R>
 > =>
   setDefaults(options ?? {}).fetch(
-    makeGetRequest(project, options),
+    makeGetProjectRequest(project, options),
   ) as Promise<
     ResponseOfEndpoint<{
       200: MemberProject | NotMemberProject;

--- a/api/users.ts
+++ b/api/users.ts
@@ -1,1 +1,1 @@
-export * as me from "./users/me.ts";
+export * from "./users/me.ts";

--- a/api/users/me.ts
+++ b/api/users/me.ts
@@ -13,7 +13,7 @@ import { cookie } from "../../rest/auth.ts";
  * @param init - Options including `connect.sid` (session ID) and other configuration
  * @returns A {@linkcode Request} object for fetching user profile data
  */
-export const makeGetRequest = <R extends Response | undefined>(
+export const makeGetUserRequest = <R extends Response | undefined>(
   init?: BaseOptions<R>,
 ): Request => {
   const { sid, baseURL } = setDefaults(init ?? {});
@@ -30,11 +30,11 @@ export const makeGetRequest = <R extends Response | undefined>(
  * @param init - Options including `connect.sid` (session ID) and other configuration
  * @returns A {@linkcode Response} object containing the user profile data
  */
-export const get = <R extends Response | undefined = Response>(
+export const getUser = <R extends Response | undefined = Response>(
   init?: BaseOptions<R>,
 ): Promise<
   ResponseOfEndpoint<{ 200: MemberUser | GuestUser }, R>
 > =>
   setDefaults(init ?? {}).fetch(
-    makeGetRequest(init),
+    makeGetUserRequest(init),
   ) as Promise<ResponseOfEndpoint<{ 200: MemberUser | GuestUser }, R>>;


### PR DESCRIPTION
This PR refactors the API exports to remove all namespace exports and use unique identifiers for each API method. Previously, API routes were structured to match the REST endpoint hierarchy, with each endpoint exported as a namespace (e.g., `pages.project.title.get()`). This allowed method chaining but caused several issues:

- Documentation for namespace exports was not properly rendered on jsr.io, sometimes resulting in 404 errors.
- The method chain style (e.g., `pages.project.title.get()`) was rarely used in practice.
- Tree-shaking was ineffective, leading to unnecessarily large bundle sizes.

**Changes in this PR:**
- All namespace exports are removed.
- Each endpoint now exports functions with unique, collision-free identifiers (e.g., `getPage`).
- Intermediate route files and `api.ts` re-export these functions directly, without wrapping them in namespaces.

**BREAKING CHANGE:**
Consumers must now import API methods as individual functions rather than accessing them via namespaces. This improves documentation compatibility and enables better tree-shaking for smaller bundles.