### PR TITLE
feat: add unstable-procedure submodule for high-level functions

### DIFF
--- a/api/pages/project.ts
+++ b/api/pages/project.ts
@@ -3,23 +3,10 @@ import type {
   NotLoggedInError,
   NotMemberError,
   PageList,
-  PageSummary,
 } from "@cosense/types/rest";
 import { type BaseOptions, setDefaults } from "../../util.ts";
 import { cookie } from "../../rest/auth.ts";
-import type {
-  ResponseOfEndpoint,
-  TargetedResponse,
-} from "../../targeted_response.ts";
-import {
-  type HTTPError,
-  makeError,
-  makeHTTPError,
-  type TypedError,
-} from "../../error.ts";
-import { pooledMap } from "@std/async/pool";
-import { range } from "@core/iterutil/range";
-import { flatten } from "@core/iterutil/async/flatten";
+import type { ResponseOfEndpoint } from "../../targeted_response.ts";
 
 /** Options for {@linkcode listPages}
  *
@@ -124,84 +111,10 @@ export const listPages = <R extends Response | undefined = Response>(
     }, R>
   >;
 
-/**
- * Options for {@linkcode listPagesStream}
- *
- * @experimental **UNSTABLE**: New API, yet to be vetted.
- */
-export interface ListPagesStreamOption<R extends Response | undefined>
-  extends ListPagesOption<R> {
-  /** The number of requests to make concurrently
-   *
-   * @default {3}
-   */
-  poolLimit?: number;
-}
-
-/**
- * Lists pages from a given `project` with pagination
- *
- * @experimental **UNSTABLE**: New API, yet to be vetted.
- *
- * @param project The project name to list pages from
- * @param options Configuration options for pagination and sorting
- * @throws {HTTPError | TypedError<"NotLoggedInError" | "NotMemberError" | "NotFoundError">} If any requests in the pagination sequence fail
- */
-export async function* listPagesStream(
-  project: string,
-  options?: ListPagesStreamOption<Response>,
-): AsyncGenerator<PageSummary, void, unknown> {
-  const props = {
-    ...(options ?? {}),
-    skip: options?.skip ?? 0,
-    limit: options?.limit ?? 100,
-  };
-  const response = await ensureResponse(await listPages(project, props));
-  const list = await response.json();
-  yield* list.pages;
-
-  const limit = list.limit;
-  const skip = list.skip + limit;
-  const times = Math.ceil((list.count - skip) / limit);
-
-  yield* flatten(
-    pooledMap(
-      options?.poolLimit ?? 3,
-      range(0, times - 1),
-      async (i) => {
-        const response = await ensureResponse(
-          await listPages(project, { ...props, skip: skip + i * limit, limit }),
-        );
-        const list = await response.json();
-        return list.pages;
-      },
-    ),
-  );
-}
-
-const ensureResponse = async (
-  response: ResponseOfEndpoint<{
-    200: PageList;
-    404: NotFoundError;
-    401: NotLoggedInError;
-    403: NotMemberError;
-  }, Response>,
-): Promise<TargetedResponse<200, PageList>> => {
-  switch (response.status) {
-    case 200:
-      return response;
-    case 401:
-    case 403:
-    case 404: {
-      const error = await response.json();
-      throw makeError(error.name, error.message) satisfies TypedError<
-        "NotLoggedInError" | "NotMemberError" | "NotFoundError"
-      >;
-    }
-    default:
-      throw makeHTTPError(response) satisfies HTTPError;
-  }
-};
+/** @deprecated Use {@link import("../../unstable-procedure/list-pages-stream.ts").listPagesStream} instead */
+export { listPagesStream } from "../../unstable-procedure/list-pages-stream.ts";
+/** @deprecated Use {@link import("../../unstable-procedure/list-pages-stream.ts").listPagesStream} instead */
+export type { ListPagesStreamOption } from "../../unstable-procedure/list-pages-stream.ts";
 
 export * from "./project/replace.ts";
 export * from "./project/search.ts";

--- a/api/pages/project/search/titles.ts
+++ b/api/pages/project/search/titles.ts
@@ -7,12 +7,6 @@ import type {
 import type { ResponseOfEndpoint } from "../../../../targeted_response.ts";
 import { type BaseOptions, setDefaults } from "../../../../util.ts";
 import { cookie } from "../../../../rest/auth.ts";
-import {
-  type HTTPError,
-  makeError,
-  makeHTTPError,
-  type TypedError,
-} from "../../../../error.ts";
 
 /**
  * Options for {@linkcode getLinks}
@@ -83,45 +77,5 @@ export const getLinks = <R extends Response | undefined = Response>(
     }, R>
   >;
 
-/** Retrieve all link data from a specified project one by one
- *
- * @experimental **UNSTABLE**: New API, yet to be vetted.
- *
- * @param project The project name to list pages from
- * @param options Additional configuration options for the request
- * @returns An async generator that yields each link data
- * @throws {TypedError<"NotLoggedInError" | "NotMemberError" | "NotFoundError" | "InvalidFollowingIdError"> | HTTPError}
- */
-export async function* getLinksStream(
-  project: string,
-  options?: GetLinksOptions<Response>,
-): AsyncGenerator<SearchedTitle, void, unknown> {
-  let followingId = options?.followingId ?? "";
-  do {
-    const response = await getLinks(project, { ...options, followingId });
-    switch (response.status) {
-      case 200:
-        break;
-      case 401:
-      case 403:
-      case 404: {
-        const error = await response.json();
-        throw makeError(error.name, error.message) satisfies TypedError<
-          "NotLoggedInError" | "NotMemberError" | "NotFoundError"
-        >;
-      }
-      case 422:
-        throw makeError(
-          "InvalidFollowingIdError",
-          (await response.json()).message,
-        ) satisfies TypedError<
-          "InvalidFollowingIdError"
-        >;
-      default:
-        throw makeHTTPError(response) satisfies HTTPError;
-    }
-    const titles = await response.json();
-    yield* titles;
-    followingId = response.headers.get("X-following-id") ?? "";
-  } while (followingId);
-}
+/** @deprecated Use {@link import("../../../../unstable-procedure/get-links-stream.ts").getLinksStream} instead */
+export { getLinksStream } from "../../../../unstable-procedure/get-links-stream.ts";

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -22,6 +22,7 @@
     "./text": "./text.ts",
     "./title": "./title.ts",
     "./unstable-api": "./api.ts",
+    "./unstable-procedure": "./unstable-procedure/mod.ts",
     "./unstable-api/pages": "./api/pages.ts",
     "./unstable-api/commits": "./api/commits.ts",
     "./unstable-api/commits/project": "./api/commits/project.ts",

--- a/rest/mod.ts
+++ b/rest/mod.ts
@@ -19,7 +19,6 @@ export * from "./auth.ts";
 export type { BaseOptions, ExtendedOptions } from "./options.ts";
 export * from "./getCodeBlocks.ts";
 export * from "./getCodeBlock.ts";
-export * from "./uploadToGCS.ts";
 export * from "./getCachedAt.ts";
 
 export type { HTTPError } from "./responseIntoResult.ts";

--- a/unstable-procedure/get-links-stream.ts
+++ b/unstable-procedure/get-links-stream.ts
@@ -1,0 +1,121 @@
+/** Stream link data from a project with pagination
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @param project The project name to list pages from
+ * @param options Additional configuration options for the request
+ * @yields {@linkcode Result}<{@linkcode SearchedTitle}, {@linkcode HTTPError} | {@linkcode TypedError}<"NotLoggedInError" | "NotMemberError" | "NotFoundError" | "InvalidFollowingIdError">>
+ */
+
+import type {
+  NotFoundError,
+  NotLoggedInError,
+  NotMemberError,
+  SearchedTitle,
+} from "@cosense/types/rest";
+import {
+  createErr,
+  createOk,
+  isErr,
+  type Result,
+  unwrapErr,
+  unwrapOk,
+} from "option-t/plain_result";
+import {
+  type HTTPError,
+  makeError,
+  makeHTTPError,
+  type TypedError,
+} from "../error.ts";
+import type { ResponseOfEndpoint } from "../targeted_response.ts";
+import {
+  getLinks,
+  type GetLinksOptions,
+} from "../api/pages/project/search/titles.ts";
+
+const toResult = async (
+  response: ResponseOfEndpoint<{
+    200: SearchedTitle[];
+    404: NotFoundError;
+    401: NotLoggedInError;
+    403: NotMemberError;
+    422: { message: string };
+  }, Response>,
+): Promise<
+  Result<
+    Response,
+    | TypedError<
+      "NotLoggedInError" | "NotMemberError" | "NotFoundError" |
+        "InvalidFollowingIdError"
+    >
+    | HTTPError
+  >
+> => {
+  switch (response.status) {
+    case 200:
+      return createOk(response);
+    case 401:
+    case 403:
+    case 404: {
+      const error = await response.json();
+      return createErr(
+        makeError(
+          error.name,
+          error.message,
+        ) as TypedError<
+          "NotLoggedInError" | "NotMemberError" | "NotFoundError"
+        >,
+      );
+    }
+    case 422:
+      return createErr(
+        makeError(
+          "InvalidFollowingIdError",
+          (await response.json()).message,
+        ) as TypedError<"InvalidFollowingIdError">,
+      );
+    default:
+      return createErr(makeHTTPError(response));
+  }
+};
+
+/** Retrieve all link data from a specified project one by one
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @param project The project name to list pages from
+ * @param options Additional configuration options for the request
+ * @returns An async generator that yields each link data
+ */
+export async function* getLinksStream(
+  project: string,
+  options?: GetLinksOptions<Response>,
+): AsyncGenerator<
+  Result<
+    SearchedTitle,
+    | HTTPError
+    | TypedError<
+      "NotLoggedInError" | "NotMemberError" | "NotFoundError" |
+        "InvalidFollowingIdError"
+    >
+  >,
+  void,
+  unknown
+> {
+  let followingId = options?.followingId ?? "";
+  do {
+    const result = await toResult(
+      await getLinks(project, { ...options, followingId }),
+    );
+    if (isErr(result)) {
+      yield createErr(unwrapErr(result));
+      return;
+    }
+    const response = unwrapOk(result);
+    const titles: SearchedTitle[] = await response.json();
+    for (const title of titles) {
+      yield createOk(title);
+    }
+    followingId = response.headers.get("X-following-id") ?? "";
+  } while (followingId);
+}

--- a/unstable-procedure/list-pages-stream.ts
+++ b/unstable-procedure/list-pages-stream.ts
@@ -1,0 +1,153 @@
+/** Stream paginated pages from a project
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @param project The project name to list pages from
+ * @param options Configuration options for pagination and sorting
+ * @yields {@linkcode Result}<{@linkcode PageSummary}, {@linkcode HTTPError} | {@linkcode TypedError}<"NotFoundError" | "NotLoggedInError" | "NotMemberError">>
+ */
+
+import type {
+  NotFoundError,
+  NotLoggedInError,
+  NotMemberError,
+  PageList,
+  PageSummary,
+} from "@cosense/types/rest";
+import {
+  createErr,
+  createOk,
+  isErr,
+  type Result,
+  unwrapErr,
+  unwrapOk,
+} from "option-t/plain_result";
+import {
+  type HTTPError,
+  makeError,
+  makeHTTPError,
+  type TypedError,
+} from "../error.ts";
+import type { ResponseOfEndpoint } from "../targeted_response.ts";
+import { pooledMap } from "@std/async/pool";
+import { range } from "@core/iterutil/range";
+import { flatten } from "@core/iterutil/async/flatten";
+import { listPages, type ListPagesOption } from "../api/pages/project.ts";
+
+/** Options for {@linkcode listPagesStream}
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ */
+export interface ListPagesStreamOption<R extends Response | undefined>
+  extends ListPagesOption<R> {
+  /** The number of requests to make concurrently
+   *
+   * @default {3}
+   */
+  poolLimit?: number;
+}
+
+const toResult = async (
+  response: ResponseOfEndpoint<{
+    200: PageList;
+    404: NotFoundError;
+    401: NotLoggedInError;
+    403: NotMemberError;
+  }, Response>,
+): Promise<
+  Result<
+    PageList,
+    TypedError<"NotFoundError" | "NotLoggedInError" | "NotMemberError"> |
+      HTTPError
+  >
+> => {
+  switch (response.status) {
+    case 200:
+      return createOk(await response.json());
+    case 401:
+    case 403:
+    case 404: {
+      const error = await response.json();
+      return createErr(
+        makeError(
+          error.name,
+          error.message,
+        ) as TypedError<
+          "NotLoggedInError" | "NotMemberError" | "NotFoundError"
+        >,
+      );
+    }
+    default:
+      return createErr(makeHTTPError(response));
+  }
+};
+
+/** Lists pages from a given `project` with pagination
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @param project The project name to list pages from
+ * @param options Configuration options for pagination and sorting
+ */
+export async function* listPagesStream(
+  project: string,
+  options?: ListPagesStreamOption<Response>,
+): AsyncGenerator<
+  Result<
+    PageSummary,
+    HTTPError | TypedError<
+      "NotFoundError" | "NotLoggedInError" | "NotMemberError"
+    >
+  >,
+  void,
+  unknown
+> {
+  const props = {
+    ...(options ?? {}),
+    skip: options?.skip ?? 0,
+    limit: options?.limit ?? 100,
+  };
+  const result = await toResult(await listPages(project, props));
+  if (isErr(result)) {
+    yield createErr(unwrapErr(result));
+    return;
+  }
+  const list = unwrapOk(result);
+  for (const page of list.pages) {
+    yield createOk(page);
+  }
+
+  const limit = list.limit;
+  const skip = list.skip + limit;
+  const times = Math.ceil((list.count - skip) / limit);
+
+  yield* flatten(
+    pooledMap(
+      options?.poolLimit ?? 3,
+      range(0, times - 1),
+      async (
+        i,
+      ): Promise<
+        Result<
+          PageSummary,
+          HTTPError | TypedError<
+            "NotFoundError" | "NotLoggedInError" | "NotMemberError"
+          >
+        >[]
+      > => {
+        const result = await toResult(
+          await listPages(project, {
+            ...props,
+            skip: skip + i * limit,
+            limit,
+          }),
+        );
+        if (isErr(result)) {
+          return [createErr(unwrapErr(result))];
+        }
+        const list = unwrapOk(result);
+        return list.pages.map((page) => createOk(page));
+      },
+    ),
+  );
+}

--- a/unstable-procedure/mod.ts
+++ b/unstable-procedure/mod.ts
@@ -1,0 +1,11 @@
+/** High-level procedures built on Cosense REST API
+ *
+ * @module
+ *
+ * These functions compose multiple API requests to provide higher-level
+ * operations such as streaming pagination, multi-step uploads, etc.
+ */
+
+export { listPagesStream } from "./list-pages-stream.ts";
+export { getLinksStream } from "./get-links-stream.ts";
+export { uploadToGCS } from "./upload-to-gcs.ts";

--- a/unstable-procedure/upload-to-gcs.ts
+++ b/unstable-procedure/upload-to-gcs.ts
@@ -1,9 +1,9 @@
-import { cookie, getCSRFToken } from "./auth.ts";
+import { cookie, getCSRFToken } from "../rest/auth.ts";
 import {
   type BaseOptions,
   type ExtendedOptions,
   setDefaults,
-} from "./options.ts";
+} from "../rest/options.ts";
 import type { ErrorLike, NotFoundError } from "@cosense/types/rest";
 import { md5 } from "@takker/md5";
 import { encodeHex } from "@std/encoding/hex";
@@ -18,8 +18,8 @@ import {
   unwrapOk,
 } from "option-t/plain_result";
 import { toResultOkFromMaybe } from "option-t/maybe";
-import type { FetchError } from "./robustFetch.ts";
-import { type HTTPError, responseIntoResult } from "./responseIntoResult.ts";
+import type { FetchError } from "../rest/robustFetch.ts";
+import { type HTTPError, responseIntoResult } from "../rest/responseIntoResult.ts";
 
 /** Metadata for the uploaded file */
 export interface GCSFile {


### PR DESCRIPTION
## Summary

Create a new `unstable-procedure/` submodule for high-level functions that compose multiple API requests, separating them from the thin fetch wrapper `unstable-api/`.

## Changes

### New module: `unstable-procedure/`
- **`list-pages-stream.ts`**: Migrated from `api/pages/project.ts`. Changed error handling from throw to `Result` type (option-t), yielding `createErr` on failure and returning.
- **`get-links-stream.ts`**: Migrated from `api/pages/project/search/titles.ts`. Same throw → `Result` conversion.
- **`upload-to-gcs.ts`**: Migrated from `rest/uploadToGCS.ts`. Logic unchanged; only import paths updated.

### Modified files
- **`api/pages/project.ts`**: `listPagesStream` / `ensureResponse` removed, `@deprecated` re-export added
- **`api/pages/project/search/titles.ts`**: `getLinksStream` removed, `@deprecated` re-export added
- **`rest/mod.ts`**: `uploadToGCS` export removed
- **`deno.jsonc`**: `./unstable-procedure` export added

### Deleted
- **`rest/uploadToGCS.ts`**: Moved to `unstable-procedure/upload-to-gcs.ts`

## Design

| Submodule | Error handling | Philosophy |
|-----------|---------------|------------|
| `unstable-api/` | throw / Response | Thin fetch wrapper, no option-t |
| `unstable-procedure/` | Result (option-t) | High-level multi-request operations |